### PR TITLE
[FIX][#39] 이미 가입된 유저가 로그인하는 경우 처리

### DIFF
--- a/Yomang/Sources/View/AppleLoginButtonView.swift
+++ b/Yomang/Sources/View/AppleLoginButtonView.swift
@@ -78,6 +78,7 @@ struct AppleLoginButtonView: View {
                     
                     guard let email = appleIDCredential.email else {
                         print("Already Signed in")
+                        viewModel.signInUser(credential: credential)
                         return
                     }
                     

--- a/Yomang/Sources/ViewModel/AuthViewModel.swift
+++ b/Yomang/Sources/ViewModel/AuthViewModel.swift
@@ -48,7 +48,7 @@ class AuthViewModel: ObservableObject {
     }
     
     // 유저를 서버에 등록하고 (회원가입) 각 유저에게 부여되는 고유한 코드를 생성함
-    func signInUser(credential: AuthCredential, email: String, partnerId: String?, _ completion: @escaping(String) -> Void?) {
+    func signInUser(credential: AuthCredential, email: String, partnerId: String?, _ completion: @escaping(String) -> Void) {
         Auth.auth().signIn(with: credential) { (result, error) in
             // 서버에서 데이터를 받아오지 못했을 경우 별도의 작업 수행 없이 return
             if let error = error {
@@ -77,6 +77,13 @@ class AuthViewModel: ObservableObject {
                     completion(user.uid)
                 }
             }
+        }
+    }
+    
+    func signInUser(credential: AuthCredential) {
+        Auth.auth().signIn(with: credential) { _, _ in
+            self.userSession = Auth.auth().currentUser
+            self.fetchUser { _ in }
         }
     }
     


### PR DESCRIPTION
clsoe #39 

# Description
이미 가입된 유저가 다른 기기로 또는 재설치 후 로그인하는 경우 애플로 로그인 화면에서 넘어가지 않는 버그가 있었습니다.
다시 로그인하고 해당 AuthCredential을 갖고 로그인합니다