### PR TITLE
[FIX][#101] 회원탈퇴 후 앱 재시동 안하면 오류나는 문제를 회원탈퇴 완료 시 앱이 꺼지게 해서 해결

### DIFF
--- a/Yomang/Sources/ContentView.swift
+++ b/Yomang/Sources/ContentView.swift
@@ -9,6 +9,8 @@ struct ContentView: View {
     @State var navigateToYomangView = false
     @State var nickname: String = "나의 닉네임"
     
+    @StateObject var authViewModelSingleton = AuthViewModel.shared
+    
     var body: some View {
         ZStack {
             Color.black.ignoresSafeArea()
@@ -43,6 +45,13 @@ struct ContentView: View {
                     navigateToYomangView = true
                 }
             })
+        }
+        .alert("회원탈퇴가 완료되었습니다.", isPresented: $authViewModelSingleton.isQuit) {
+            Button("확인", role: .cancel) {
+                exit(0)
+            }
+        } message: {
+            Text("애플리케이션을 종료합니다.\n다음에 또 만나요.")
         }
     }
 }

--- a/Yomang/Sources/ViewModel/AuthViewModel.swift
+++ b/Yomang/Sources/ViewModel/AuthViewModel.swift
@@ -23,6 +23,9 @@ class AuthViewModel: ObservableObject {
     @Published var user: User?
     @Published var username: String?
     @Published var shareLink: String = "itms-apps://itunes.apple.com/app/6461822956"
+
+    // 회원탈퇴 시 사용
+    @Published var isQuit = false
     
     init() {
         self.userSession = Auth.auth().currentUser
@@ -303,6 +306,7 @@ class AuthViewModel: ObservableObject {
                 currentUser.delete { err in
                     try? Auth.auth().signOut()
                     print("=== deleted error \(err)")
+                    self.isQuit = true
                     completion()
                 }
             }


### PR DESCRIPTION
close #101 

문제 : 회원탈퇴 후 앱에서 바로 회원가입을 재시도하면 LinkView가 노출되지 않고
바로 회원가입이 완료되어 버림. 이때 사용자 닉네임은 ""으로 강제 설정됨.

회원탈퇴 후 앱을 1회 껐다 켜고, 다시 회원가입을 시도하면 문제가 발생하지 않음.

접근방식 : 회원탈퇴 시 ContentView가 한번 더 새로고침 되는 것이 아닌 판정이 발생
그렇기 때문에 navigateToYomangView가 계속 true로 남아서
앱을 재시동하지 않고 바로 회원가입을 다시 하면 LinkView가 미노출되는 줄 알았으나...

시도 1 : 회원탈퇴 시 navigateToYomangView를 false로 바꿔봄.
그런데 이렇게 하니까 회원탈퇴 판정이 제대로 발생하지 않음.

시도 2 : 회원탈퇴 완료 시 팝업을 띄우고 확인 버튼을 누르면 앱을 꺼버림. 
앱을 계속 사용하고 싶으면 무조건 다시 켜야 함. 문제 해결.

원인파악 : 불명... 계속 원인 파악하다가 또 타임아웃 날 것 같아서 일단 문제를 땜질로 해결 시도

문제 해결 방식의 한계 : 원인파악을 제대로 하지 못함

의의 : 지금 방식은 회원탈퇴 시 회원탈퇴가 되었다는 사실을 유저에게 전하지 못하는데,
얼떨결에 회원탈퇴가 완료되면 사용자에게 결과를 명확하게 고지하는 프로세스를 제작하는 것에 성공함.

+ : 원래는 제대로 작동하던 "나의 이메일 가리기" 기능이 제대로 작동하지 않는 것 같은데... 이것도 한번 확인해 봐야 할 것 같아요