### PR TITLE
[FIX][#103] 버튼 두번 빠르게 다닥 누르면 글자 꼬이는 현상 해결

### DIFF
--- a/Yomang/Sources/ContentView.swift
+++ b/Yomang/Sources/ContentView.swift
@@ -9,6 +9,8 @@ struct ContentView: View {
     @State var navigateToYomangView = false
     @State var nickname: String = "나의 닉네임"
     
+    @StateObject var authViewModelSingleton = AuthViewModel.shared
+    
     var body: some View {
         ZStack {
             Color.black.ignoresSafeArea()
@@ -43,6 +45,13 @@ struct ContentView: View {
                     navigateToYomangView = true
                 }
             })
+        }
+        .alert("회원탈퇴가 완료되었습니다.", isPresented: $authViewModelSingleton.isQuit) {
+            Button("확인", role: .cancel) {
+                exit(0)
+            }
+        } message: {
+            Text("애플리케이션을 종료합니다.\n다음에 또 만나요.")
         }
     }
 }

--- a/Yomang/Sources/View/LinkView.swift
+++ b/Yomang/Sources/View/LinkView.swift
@@ -215,7 +215,7 @@ struct LinkView: View {
                         }
                         .disabled(displayedText < fullText || displayedText2 < fullText2)
                         .simultaneousGesture(TapGesture().onEnded {
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                                 flowCount = 4
                             }
                         })

--- a/Yomang/Sources/ViewModel/AuthViewModel.swift
+++ b/Yomang/Sources/ViewModel/AuthViewModel.swift
@@ -23,6 +23,9 @@ class AuthViewModel: ObservableObject {
     @Published var user: User?
     @Published var username: String?
     @Published var shareLink: String = "itms-apps://itunes.apple.com/app/6461822956"
+
+    // 회원탈퇴 시 사용
+    @Published var isQuit = false
     
     init() {
         self.userSession = Auth.auth().currentUser
@@ -303,6 +306,7 @@ class AuthViewModel: ObservableObject {
                 currentUser.delete { err in
                     try? Auth.auth().signOut()
                     print("=== deleted error \(err)")
+                    self.isQuit = true
                     completion()
                 }
             }


### PR DESCRIPTION
close #103 

문제 원인 : 텍스트 출력 완료 이전에 링크 생성 시 비동기처리가 꼬임
해결 방법 : 텍스트가 끝까지 출력될 수 있도록 다음 화면으로 넘어가기 전에 대기하는 시간 여유를 1초 더 줌 (1초 -> 2초로 상향, 디스패치큐)

추가 문제 : 회원가입과 탈퇴를 단시간에 반복하다 보니 간헐적으로 회원탈퇴가 안 되는 현상이 있는데, 버그 재현이 안 됨... 문제 원인이 무엇인지 파악 불가